### PR TITLE
Re-add CS Machine Support for Makefile / Other adjustments

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -5,7 +5,7 @@
             "label": "Boot QEMU",
             "type": "shell",
             "command": "make",
-            "args": ["qemu-gdb"],
+            "args": ["MODE=local", "qemu-gdb"],
             "isBackground": true,
             "problemMatcher": {
                 "pattern":{

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,20 @@ endif
 
 TOP = .
 
-GDBPORT	:= 5000
+# This will differenciate between running locally or on the CS machine. Default to the CS machine
+MODE ?= cs
+
+ifeq ($(MODE),cs)
+	GDBPORT := $(shell expr `id -u` % 5000 + 25000)
+	CFLAGS += -gstabs
+	QEMU = /home/course/csci352/bin/qemu-system-i386
+else ifeq ($(MODE),local)
+	GDBPORT := 5000
+	CFLAGS += -g -march=i686
+	QEMU = qemu-system-i386
+else
+	$(error Unknown MODE '$(MODE)', valid options are 'local' or 'cs')
+endif
 
 CC	:= $(GCCPREFIX)gcc -pipe
 GDB	:= $(GCCPREFIX)gdb
@@ -29,8 +42,6 @@ LD	:= $(GCCPREFIX)ld
 OBJCOPY	:= $(GCCPREFIX)objcopy
 OBJDUMP	:= $(GCCPREFIX)objdump
 NM	:= $(GCCPREFIX)nm
-
-QEMU = qemu-system-i386
 
 # Native commands
 NCC	:= gcc $(CC_VER) -pipe
@@ -45,7 +56,7 @@ CFLAGS := $(CFLAGS) $(DEFS) $(LABDEFS) -O1 -fno-builtin -I$(TOP) -MD
 CFLAGS += -fno-omit-frame-pointer
 CFLAGS += -std=gnu99
 CFLAGS += -static
-CFLAGS += -Wall -Wno-format -Wno-unused -Werror -g -m32 -march=i686
+CFLAGS += -Wall -Wno-format -Wno-unused -Werror -m32 -march=i686
 # -fno-tree-ch prevented gcc from sometimes reordering read_ebp() before
 # mon_backtrace()'s function prologue on gcc version: (Debian 4.7.2-5) 4.7.2
 CFLAGS += -fno-tree-ch
@@ -81,8 +92,8 @@ all:
 	   $(OBJDIR)/lib/%.o $(OBJDIR)/fs/%.o $(OBJDIR)/net/%.o \
 	   $(OBJDIR)/user/%.o
 
-KERN_CFLAGS := $(CFLAGS) -DJOS_KERNEL -g
-USER_CFLAGS := $(CFLAGS) -DJOS_USER -g
+KERN_CFLAGS := $(CFLAGS) -DJOS_KERNEL
+USER_CFLAGS := $(CFLAGS) -DJOS_USER
 
 # Update .vars.X if variable X has changed since the last make run.
 #

--- a/kern/kdebug.c
+++ b/kern/kdebug.c
@@ -143,6 +143,29 @@ debuginfo_eip(uintptr_t addr, struct Eipdebuginfo *info)
 
 		// +++ Activity 2: YOUR CODE HERE
 
+		// Validate user access to USD
+		if (user_mem_check(curenv, usd, sizeof(*usd), PTE_U | PTE_P) < 0) {
+			return -1;
+		}
+
+		// Fetch the stab data from the USD
+		stabs = usd->stabs;
+		stab_end = usd->stab_end;
+		stabstr = usd->stabstr;
+		stabstr_end = usd->stabstr_end;
+
+		// Validate user access to stabs
+		size_t stabs_size = (stab_end - stabs) * sizeof(struct Stab);
+		if (user_mem_check(curenv, stabs, stabs_size, PTE_U | PTE_P) < 0) {
+			return -1;
+		}
+
+		// Validate user access to stabstr
+		size_t stabstr_size = (stabstr_end - stabstr);
+		if (user_mem_check(curenv, stabstr, stabstr_size, PTE_U | PTE_P) < 0) {
+			return -1;
+		}
+
 		stabs = usd->stabs;
 		stab_end = usd->stab_end;
 		stabstr = usd->stabstr;

--- a/kern/syscall.c
+++ b/kern/syscall.c
@@ -21,7 +21,7 @@ sys_cputs(const char *s, size_t len)
 	// Destroy the environment if not.
 
 	if (user_mem_check(curenv, s, len, PTE_U) < 0) {
-		cprintf("[%08x] User attempted to access [%08x] but its not user readable", curenv->env_id, (uintptr_t)s);
+		cprintf("[%08x] user_mem_check assertion failure for va [%08x]\n", curenv->env_id, (uintptr_t)s);
 		env_destroy(curenv);
 	}
 


### PR DESCRIPTION
This PR does 3 things

- The Makefile now compiles for the CS machine by default (running `make MODE=local ...` will compile and run for the local environment)
- Adjusts the wording when user_mem_check fails in a syscall to better align with the project instructions
- Added memory checks to kdebug.c